### PR TITLE
add empty events array to function creation to allow it to play nice with serverless s3 local

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline-local-authorizers-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "./dist/index.js",
   "files": [
     "dist",

--- a/src/lib/AwsLocalAuthorizersPlugin.ts
+++ b/src/lib/AwsLocalAuthorizersPlugin.ts
@@ -91,7 +91,7 @@ export class AwsLocalAuthorizerPlugin {
                 memorySize: 256,
                 timeout: 30,
                 handler: "local-authorizers." + authorizerName,
-                events: null,
+                events: [],
                 name: `${this.serverless.service.service}-${this.options.stage}-${authorizerName}`,
             };
             prev[authorizerName] = functionKey;


### PR DESCRIPTION
@nlang 
S3 local runs through each function in a serverless yaml file and gets a list of all events. Currently it fails when using this package since the events property is null and cannot be mapped. 