### PR TITLE
feat: allowing to choose path and file type

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm i serverless-offline-local-authorizers-plugin --save-dev
 
 ## Usage
 
-*Step 1:* Define your authorizer functions in a file called `local-authorizers.js` and put it into your
+*Step 1:* Define your authorizer functions in a file of your choice (.js, .mjs, .ts and others) and later you will inform the path and name or file default called `local-authorizers.js` and put it into your
 project root (that's where your `serverless.yml` lives).
 
 If you want the local function to call your deployed shared authorizer it could look something
@@ -71,6 +71,7 @@ functions:
             authorizerId: abcjfk
           localAuthorizer:
             name: "mylocalAuthProxyFn"
+            pathFile: "local-authorizers.js" # Optional
             type: "request"
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "serverless-offline-local-authorizers-plugin",
       "version": "1.3.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
         "@types/node": "14.18.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-offline-local-authorizers-plugin",
-  "version": "1.1.2",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-offline-local-authorizers-plugin",
-      "version": "1.1.2",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "14.18.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "serverless-offline-local-authorizers-plugin",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "./dist/index.js",
+  "scripts": {
+    "build": "npx tsc",
+    "prepare": "npx tsc"
+  },
   "files": [
     "dist",
     "package.json",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "npx tsc",
-    "prepare": "npx tsc"
+    "install": "npx tsc"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.3.0",
   "main": "./dist/index.js",
   "scripts": {
-    "build": "npx tsc",
-    "install": "npx tsc"
+    "tsc": "./node_modules/typescript/bin/tsc",
+    "postinstall": "npm run tsc"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "tsc": "./node_modules/typescript/bin/tsc",
+    "install": "npm install",
     "postinstall": "npm run tsc"
   },
   "files": [


### PR DESCRIPTION
@nlang  I made a big modification but I hope it will be appreciated by you.

At first I tried not to break what already exists, but I had to remove validation from the file. However if the files are wrong the serverless will burst error.

What I had to do was remove the file verification to allow a typescript file that esbuild automatically converts to mjs (esmudule). Otherwise, I wouldn't be able to use this library (esbuild always converts)